### PR TITLE
Tab-content section was duplicated

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,35 +562,6 @@ Sliding direction. The value can be one of the following:
 	  </table>	
       <p>The 'tab-content' component not support additional events except the common events.</p>	  
 	</section>	
-	<section>
-     <h2>tab-content</h2>
-     <p>The 'tab-content' is a child component of 'tabs' and is used to provide the area for displaying the tab content. By default, its height is such that all the remaining space of the 'tabs' component is filled. The child components are arranged horizontally. When 'tab-content' is used as a child element in a container, the length on the main axis direction must be specified. Otherwise, the child element cannot be displayed.</p>
-	 <p>Attributes supported by 'tab-content' are similar to those supported by 'tabs'. In addition to the attributes supported by 'tabs', 'tab-content' supports the following attributes as well:</p>
-      <table class="members">
-        <caption>Attributes for tab-bar component</caption>
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Type</th>			
-            <th scope="col">Default Value</th>
-            <th scope="col">Mandatory</th>			
-            <th scope="col">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><code>Scrollable</code></th>
-            <td>Boolean</td>
-			<td>Truth</td>
-			<td>No</td>
-            <td>
-              <span>Whether the tabs can be switched by swiping left or right. The default value is true. If this attribute is set to false, tab switching is implemented only through the association with tab-bar.</span>
-            </td>
-          </tr>			  
-		</tbody>		
-	  </table>	
-      <p>The 'tab-content' component not support additional events except the common events.</p>	  
-	</section>
     <section>
      <h2>refresh</h2>
 	 <p>The 'refresh' component is used to pull down to refresh the page.</p>


### PR DESCRIPTION
Removes additional duplicate copy of 'tab-content' section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cwilso/miniapp-components/pull/1.html" title="Last updated on Jul 21, 2021, 7:29 PM UTC (0935787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-components/1/4a35a69...cwilso:0935787.html" title="Last updated on Jul 21, 2021, 7:29 PM UTC (0935787)">Diff</a>