### PR TITLE
MiniApp Components Explainer

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -18,7 +18,7 @@ This document aims to specify a set of common practices to define MiniApps Compo
 
 Although MiniApps Components share the same concept as Web Components, their capabilities and development features differ. The main differences are motivated by the architecture of the existing implementations along the MiniApp ecosystem following the MVVM pattern, based on components developed through domain-specific markup languages and without access to the standard DOM. 
 
-Even though the MiniApp Packaging specification recommends MiniApp agents to support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
+Even though the MiniApp Packaging specification recommends that MiniApp agents support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
 
 ## 2. Scope of work
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -628,13 +628,15 @@ In MiniApps, listeners must be defined in specific places in the logic of the co
 
 ##### Alipay Mini Program
 
-`function()` declaration in the root of the `Page({})` declaration in the script.
+`function()` declaration in the root of the `methods` object within the `Component({})` declaration in the script.
 
 ```js
-Page ({
-  loadMore(e) {
-    console.log(e);
-  },
+Component ({
+  methods: {
+    loadMore(e) {
+      console.log(e);
+    }
+  }
 });
 ```
 
@@ -642,7 +644,7 @@ Page ({
 
 ##### Baidu Smart Mini Program
 
-`function()` declaration in the root of the `Page({})` declaration in the script.
+`function()` declaration in the root of the `Component({})` declaration in the script.
 
 ```js
 Page({

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -741,7 +741,7 @@ Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/
 [Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) are extensions of [HTML elements](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) that need to be registered to be used in the document. Apart from the inherited event handlers, custom elements have associated specific callbacks associated with their lifecycle statuses and events. 
 
 - `connectedCallback` is invoked when the custom element is first connected to the document's DOM. 
-- `disconnectedCallback` invoked when the custom element is disconnected from the document's DOM.
+- `disconnectedCallback` is invoked when the custom element is disconnected from the document's DOM.
 - `adoptedCallback` is invoked when the custom element is moved to a new document.
 - `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed. 
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -230,7 +230,7 @@ Component ({
 
 #### Component markup language
 
-Although the MiniApp components templates are based on HTML, the concrete implementations use their domain-specific markup languages.    
+Although the MiniApp components templates are based on HTML, the concrete [implementations use their domain-specific markup languages](https://web.dev/mini-app-markup-styling-and-scripting/#markup-languages).    
 
 ##### Quick App (Xiaomi, Huawei)
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -88,7 +88,7 @@ The main differences identified are:
 
 - __Component resources__. MiniApps require specific resource types, including markup languages and file system structure. 
 - __Component interface__. MiniApps components have specific properties and methods. Access to global variables and page elements differs in all versions. 
-- __Template definition__. MiniApps have an advanced `{{moustache}}` templating mechanism with data binding and conditional rendering.
+- __Template definition__. MiniApps have an advanced one-way data binding, with a `{{moustache}}` templating mechanism, and conditional rendering.
 - __Event management__. MiniApp event listeners are similar, but developers cannot use the `addEventListener()` method from the logic. Event interfaces are different.
 - __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties, and rules are similar. 
 
@@ -505,7 +505,7 @@ Properties as instance attributes
 
 #### Data binding
 
-All the MiniApp versions have [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to bind variables from the logic part of the component.
+All the MiniApp versions use [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to unidirectionally bind variables from the component's logic to the rendering templates.
 
 ##### Quick App (Xiaomi, Huawei)
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -886,7 +886,7 @@ The different MiniApp versions use the same `style` attribute to declare inline 
 <view style="color: #ffffff"> swan </view>
 ```
 
-#### Web Components
+##### Web Components
 
 `style` attribute in the elements.	
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -99,7 +99,7 @@ Depending on the implementation, MiniApp components are defined using specific f
 
 ##### Quick App (Xiaomi, Huawei)
 
-Quick App uses [UX documents](https://doc.quickapp.cn/framework/source-file.html) (`.ux`) to describe and use components. These documents contains three sections, `<template>`, `<script>`, and `<style>`, that include the specific template definition, logic and styling respectively. 
+Quick App uses [UX documents](https://doc.quickapp.cn/framework/source-file.html) (`.ux`) to describe and use components. These documents contain three sections, `<template>`, `<script>`, and `<style>`, that include the specific template definition, logic, and styling respectively. 
 
 Example:
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -738,7 +738,7 @@ Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/
 
 #### Lifecycle
 
-[Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) are extension of [HTML elements](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) that need to be registered to be used in the document. Apart from the inherited event handlers, custom elements have associated specific callbacks associated with their lifecycle statuses and events. 
+[Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) are extensions of [HTML elements](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) that need to be registered to be used in the document. Apart from the inherited event handlers, custom elements have associated specific callbacks associated with their lifecycle statuses and events. 
 
 - `connectedCallback` invoked when the custom element is first connected to the document's DOM. 
 - `disconnectedCallback` invoked when the custom element is disconnected from the document's DOM.

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -644,14 +644,16 @@ Component ({
 
 ##### Baidu Smart Mini Program
 
-`function()` declaration in the root of the `Component({})` declaration in the script.
+`function()` declaration in the root of the `methods` object within the `Component({})` declaration in the script.
 
 ```js
-Page({
-  loadMore(e) {
-    swan.showToast(e.type);
+Component({
+  methods: {
+    loadMore(e) {
+      swan.showToast(e.type);
+    }
   }
-});
+})
 ```
 
 [More information](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -1,60 +1,853 @@
-# MiniApp UI Components Explainer 
+# MiniApp Components Explainer 
+
 ## Authors
-Zitao Wang (Huawei)
+
+- Zitao Wang (Huawei)
+- Martin Alvarez (Huawei)
+
 ## 1. Introduction
 
 ### What is this?
-MiniApps are made of high-level building blocks called UI Components, which allow developers to quickly construct the UI for a MiniApp.
-### Why should we care?
-For MiniApp, there are some pre-standard implementations and wildly used. But these implementations may follow different vendor-specific development guidelines for developing MiniApp UI components. And some of them are defining their own markup languages (WXML, SWAN, AXML), specific event handling, data-binding and rending methods. For example:
 
-- Wechat WXML:
-```html
-  <!--wxml-->
-    <view class="page-section page-section-spacing swiper">
-      <swiper indicator-dots="{{indicatorDots}}"
-        autoplay="{{autoplay}}" interval="{{interval}}" duration="{{duration}}">
-        <block wx:for="{{background}}" wx:key="*this">
-          <swiper-item>
-            <view class="swiper-item {{item}}"></view>
-          </swiper-item>
-        </block>
-      </swiper>
-    </view>
+MiniApp Components are the building blocks to creating MiniApp pages. Each component encapsulates functionality, data, and styles, enabling developers to create custom and reusable items that can be combined to develop MiniApps. MiniApps include essential components like page containers, textual and multimedia content, and other interactive elements such as forms.
+
+This document aims to specify a set of common practices to define MiniApps Components that allow developers to build similar user interfaces across MiniApp platforms efficiently.
+
+### Why should we care?
+
+Although MiniApps Components share the same concept as Web Components, their capabilities and development features differ. The main differences are motivated by the architecture of the existing implementations along the MiniApp ecosystem following the MVVM pattern, based on components developed through domain-specific markup languages and without access to the standard DOM. 
+
+Even though [[[MINIAPP-PACKAGING]]] recommends MiniApp agents to support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
+
+
+## 2. Differences with Web Components
+
+This section analyzes the differences between the standard Web Components and the MiniApp components, considering the existing vendor-specific implementations, Baidu Smart Mini Programs, Alipay Mini Programs, and Quick Apps (Huawei, Xiaomi). 
+
+The main differences identified are:
+
+- __Component resources__. MiniApps require specific resource types, including markup languages, and file system structure. 
+- __Component interface__. MiniApp components have specific properties and methods. Access to global variables and page elements differs in all versions. 
+- __Template definition__. MiniApps have advanced `{{moustache}}` templating mechanism with data binding and conditional rendering.
+- __Event management__. MiniApp event listeners are similar, but developers cannot use the `addEventListener()` method from the logic. Event interfaces are different.
+- __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties and rules are similar. 
+
+
+### Component resources
+
+Depending on the implementation, MiniApp components are defined using specific file formats and resources to describe templates, logic and styles.
+
+#### Quick App (Xiaomi, Huawei)
+
+Quick App uses [UX documents](https://doc.quickapp.cn/framework/source-file.html) (`.ux`) to describe and use components. These documents contains three sections, `<template>`, `<script>`, and `<style>`, that include the specific template definition, logic and styling respectively. 
+
+Example:
+
+``` xml
+<template>
+  <div>
+    <text class="title" onclick="press">Hello</text>
+  </div>
+</template>
+
+<script>
+  export default {
+    press(e) {
+      this.title = 'Hello'
+    }
+  }
+</script>
+
+<style>
+  .title {
+    color: red;
+  }
+</style>
+
+``` 
+
+#### Alipay Mini Program
+
+Alipay Mini Program components may have four resources in the same directory: `.axml`, `.js`, `.json`, and `.acss`.
+
+`.axml`. AXML file including the template.
+
+``` xml
+<!-- /components/index/index.axml -->
+<view>
+  Hi, I'm a component.
+</view>
 ```
-- Baidu SWAN:
-```html
-<!-- template-demo.swan-->
-<view class="wrap">
-    <view class="card-area">
-        <swiper 
-            class="swiper"
-            indicator-dots="{{switchIndicateStatus}}" 
-            indicator-color="rgba(0,0,0,0.30)"
-            indicator-active-color="#fff">
-            <swiper-item 
-                s-for="item in swiperList"
-                item-id="{{itemId}}"
-                class="{{item.className}}">
-                <view class="swiper-item">{{item.value}}</view>
-            </swiper-item>
-        </swiper>
+
+`.js` for component registration.
+
+``` js
+// /components/index/index.js
+Component ( {
+  mixins :  [ ] ,
+  data :  { x : 1 } ,   
+  props :  { y : 1 } ,   
+  methods :  {  
+    handleTap ( )  {} , 
+  },
+})
+```
+
+`.json` to indicate that the current directory files defines a component.
+
+``` json
+// /components/index/index.json
+{
+  "component" : true 
+}
+```
+
+`.acss`. ACSS document with the stylesheet.
+
+``` css
+/** /components/index/index.acss **/
+.md-button  {
+  padding : 15px ; 
+}
+```
+
+[Read more](https://opendocs.alipay.com/mini/framework/custom-component-overview).
+
+
+#### Baidu Smart Mini Program
+
+Baidu Smart Mini Programs enable the creation of components using four resources in the same directory: `.swan`, `.js`, `.json`, and `.css`.
+
+`.swan`. SWAN file including the template.
+
+``` xml
+<!-- /components/custom/custom.swan -->
+<view class="name" bindtap="tap">
+    {{name}}{{age}}
+</view>
+```
+
+`.js` for component registration.
+
+``` js
+// /components/custom/custom.js
+Component ({
+  properties: { 
+    name: {
+      type: String,
+      value: 'swan',
+    }
+  },
+  data: {
+    age: 1
+  },
+  methods: {
+    tap(){}
+  }
+})
+```
+
+`.json` to indicate that the current directory files defines a component.
+
+``` json
+// /components/custom/custom.json
+{
+  "component" : true 
+}
+```
+
+`.css`. CSS document with the stylesheet.
+
+``` css
+/** /components/index/index.css **/
+.name {
+    color: red;
+}
+```
+
+[Read more](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
+
+
+### Component markup language
+
+Although the MiniApp components templates are based on HTML, the concrete implementations use their domain-specific markup languages.    
+
+#### Quick App (Xiaomi, Huawei)
+
+Quick Apps use a concrete notation for UX documents. Scripts, stylesheets and templates are defined under the same document, marked with the elements `<script>`, `<style>`, and `<template>`. 
+
+The component [templates are described](https://doc.quickapp.cn/framework/template.html) as an XML fragment within the `<template>` section, using HTML-like elements.
+
+``` xml
+<template>
+  <div>
+    <div for="{{list}}" tid="uniqueId">
+      <text>{{$idx}}</text>
+      <text>{{$item.uniqueId}}</text>
+    </div>
+  </div>
+</template>
+```
+
+Quick Apps offer advanced rendering controls (including conditionals, loops and decorators), as well as data and event binding. 
+
+
+#### Alipay Mini Program
+
+Alipay Mini Programs use a concrete AXML notation for the templates described in `.axml` documents. These documents are similar to XML, but without a root node.
+
+The component [templates are described](https://opendocs.alipay.com/mini/framework/axml) using specific elements.
+
+``` xml
+<!-- axml -->
+<template  name="task">
+  <view  class="task-item" >
+    <text  class= "desc" > {{taskDescription}} </text>
   </view>
-</view>     
+</template>
 ```
-- Alipay AXML:
-```.html
-<!-- pages/index/index.axml -->
- <view class="page-section-demo">
-  <swiper
-    style="height:150px"
-    class="demo-swiper">
-    <swiper-item key="swiper-item-{{index}}" a:for="{{background}}">
-     <view class="swiper-item bc_{{item.color}}">{{item.text}}</view>
-    </swiper-item>
-  </swiper>
- </view>
+
+Alipay Mini Programs offer advanced rendering controls (including conditionals and loops), as well as data and event binding. 
+
+#### Baidu Smart Mini Program
+
+Baidu Smart Mini Programs use [SWAN resources](https://smartprogram.baidu.com/docs/develop/framework/dev/). Developers use `.swan` documents to create rendering templates for the pages. 
+
+``` xml
+<view>
+    <custom-component>
+        <view>{{name}}</view>
+    </custom-component>
+</view>
 ```
+
+Baidu Smart Mini Programs offer advanced rendering controls (including conditionals and loops), as well as data and event binding. 
+
+
+### Templating
+
+Web Components are defined in terms of [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) and [templating](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) with	`<template>`, and `<slot>`.	MiniApps have different specifications.
+ 
+
+#### Quick App (Xiaomi, Huawei)
+
+Definition of `<template>` element in the root of a `.ux` document.
+
+``` xml
+<!–- file.ux -->
+<template>
+  <div class="demo-page">
+    <text class="title">Hi World</text>
+  </div>
+</template>
+``` 
+
+[More information](https://doc.quickapp.cn/framework/template.html).	
+
+#### Alipay Mini Program
+
+AXML’s `<template>` element in an `.axml` document.
+
+``` xml
+<!-- header.axml -->
+<template name="header">
+  <view>
+    <text>{{index}}:{{msg}}</text>
+  </view>
+</template>
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/axml-template).	
+
+#### Baidu Smart Mini Program
+
+SWAN document with elements within.
+
+``` xml
+<view>
+    <text class="wrap">hello world</text>
+</view>
+<text Class="wrap">hello world</text>
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/dev/).
+
+
+### Component re-use (instantiation)
+
+How developers reuse the components defined in the [previous section](#templating). 
+
+#### Quick App (Xiaomi, Huawei)
+
+`<import>` element in the root of the `.ux` document.
+
+``` xml
+<import name="comp" src="./comp"></import>
+
+<template>
+  <div>
+    <comp></comp>
+  </div>
+</template>
+```
+
+[More information](https://doc.quickapp.cn/framework/template.html).	
+
+#### Alipay Mini Program
+
+AXML’s `<import>` and `<template is=...` elements.
+
+``` xml
+<import src="./header.axml" />
+
+<template is="header" data="{{...item}}"/>
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/axml-template).
+
+#### Baidu Smart Mini Program
+
+Declaration in the configuration (`.json`) document. 
+
+``` json
+// home.json
+{
+  "usingComponents": {
+     "custom": "/components/custom/custom"
+   }
+}
+```
+
+And declaration in the SWAN document using the ID in the configuration file.
+
+``` xml
+<!-- home.swan -->
+<view>
+   <custom name="swanapp"></custom>
+</view>
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/dev/).
+
+
+### Component properties (definition)
+
+How the properties (attributes) of the components are defined in each MiniApp version. 
+
+#### Quick App (Xiaomi, Huawei)
+
+Components define properties in a `props` array within the object declared in the `<script>` section.     
+
+``` html
+<!-– comp.ux -->
+<script>
+  export default {
+    props: ['say', 'propObject'],
+    onInit() {
+      console.info(this.say);    
+      console.info(this.propObject)
+    }
+  }
+</script>
+```
+[More information](https://doc.quickapp.cn/tutorial/framework/parent-child-component-communication.html).
+
+#### Alipay Mini Program
+
+Definition of the component using `Component()` and the properties as pairs in the `props` object.
+
+``` js
+// /components/index/index.js
+Component ({
+  props : { 
+    name : 'My name'}
+});
+```
+[More information](https://opendocs.alipay.com/mini/framework/component_object).
+
+
+#### Baidu Smart Mini Program
+
+Definition of the component using `Component()` and the properties in the `properties` object.
+
+``` js
+// (custom.js)
+Component({
+  properties: {
+    name: {
+      type: String,
+      value: 'swan',
+    }
+  }
+})
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
+
+
+### Component arguments
+
+How the properties (attributes) are passed to the components when new instances are created. 
+
+#### Quick App (Xiaomi, Huawei)
+
+Use the defined `props` directly as instance's attributes.
+
+``` xml
+<import name="comp" src="./comp"></import>
+
+<template>
+  <div>
+    <comp 
+      say="First Test" 
+      prop-object="{{obj}}">
+    </comp>
+  </div>
+</template>
+```
+
+[More information](https://doc.quickapp.cn/tutorial/framework/parent-child-component-communication.html).	
+
+
+#### Alipay Mini Program
+
+Pass the properties as as instance's attributes.
+
+``` xml
+<!-- /pages/index/index.axml -->
+<comp name='Another name'></comp> 
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/component_object).	
+
+#### Baidu Smart Mini Program
+
+Properties as instance's attributes
+
+``` json
+// home.json
+{
+  "usingComponents": {
+     "custom": "/components/custom/custom"
+   }
+}
+```
+
+``` xml
+// .swan document
+<view>
+    <custom name="Passing text" >
+    </custom>
+</view>
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
+
+
+### Data binding
+
+All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to bind variables from the logic part of the component.
+
+#### Quick App (Xiaomi, Huawei)
+
+[`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables and methods under the `private` or `public` object in the script.
+
+``` xml
+<template>
+  <text>{{message}}</text>
+</template>
+
+<script>
+  export default {
+    private: {
+      message: 'Hello'
+    }
+  }
+</script>
+```
+
+[More information](https://doc.quickapp.cn/framework/template.html).	
+
+
+#### Alipay Mini Program
+
+[`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in the AXML file linked to the `Page()` corresponding `data` object variables.
+
+``` xml
+<view> {{ message }} </view>
+```
+
+``` js
+Page({ 
+   data: { 
+     message: 'Hello alipay!', 
+    }, 
+});
+```
+                                
+[More information](https://opendocs.alipay.com/mini/framework/data-binding).
+
+#### Baidu Smart Mini Program
+
+[`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in SWAN template, linked to the `Page()` corresponding `data` object variables.
+
+``` xml
+<!-- index.swan -->
+<view>{{text}}</view>
+```
+
+``` js
+// index.js
+Page({
+    data: {
+        text: 'init data',
+    }
+});
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/app_service_pagedata/).
+	
+
+### Event binding
+
+All the MiniApp version have similar mechanism to add event handlers from the template. MiniApps cannot bind listeners using `addEventListener()` from scripts.
+
+#### Quick App (Xiaomi, Huawei)
+
+`on+eventtype` (or `@+eventtype`) attribute in the template. 
+
+``` xml
+<text onclick="loadMore"></text>
+```
+
+[More information](https://doc.quickapp.cn/tutorial/framework/event-on.html).	
+
+#### Alipay Mini Program
+
+`on+eventtype` attribute in the template.
+
+``` xml
+<view onTap="loadMore">
+  More items…
+<view> 
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/events).	
+
+#### Baidu Smart Mini Program
+
+`bind:+eventtype` attribute in the template.
+
+``` xml
+<view bind:tap="loadMore">
+   More items…
+</view>
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
+
+
+### Event listener definition
+
+In MiniApps, listeners must be defined in specific places in the logic of the component. 
+
+#### Quick App (Xiaomi, Huawei)
+
+`function()` declaration as root of the object in `<script>`.
+
+``` html
+<script>
+  export default {
+    loadMore(e) {
+      console.log(e);
+    }  
+  }
+</script>
+```
+
+[More information](https://doc.quickapp.cn/tutorial/framework/event-on.html).	
+
+#### Alipay Mini Program
+
+`function()` declaration in the root of the `Page({})` declaration in the script.
+
+``` js
+Page ({
+  loadMore(e) {
+    console.log(e);
+  },
+});
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/events).	
+
+#### Baidu Smart Mini Program
+
+`function()` declaration in the root of the `Page({})` declaration in the script.
+
+``` js
+Page({
+  loadMore(e) {
+    swan.showToast(e.type);
+  }
+});
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
+
+
+### Event types
+
+Event types by default are different. Not all the standard [event types](https://html.spec.whatwg.org/multipage/indices.html#events-2) are supported.	
+
+#### Quick App (Xiaomi, Huawei)
+
+[Basic events](https://doc.quickapp.cn/tutorial/framework/event-on.html):
+
+- `touchstart`
+- `touchmove`
+- `touchend`
+- `touchcancel`
+- `click`
+- `longpress`
+- `focus`
+- `blur`
+- `appear`
+- `disappear`
+- `swipe`
+- `resize`
+
+#### Alipay Mini Program
+
+[Basic events](https://opendocs.alipay.com/mini/framework/events):
+
+- `touchStart`
+- `touchMove`
+- `touchEnd`
+- `touchCancel`
+- `tap`
+- `longTap`
+
+#### Baidu Smart Mini Program
+
+[Basic events](https://smartprogram.baidu.com/docs/develop/framework/view_incident/):
+
+- `touchstart`
+- `touchmove`
+- `touchend`
+- `touchcancel`
+- `tap`
+
+
+### Event interface properties
+
+MiniApps have different basic event interfaces. Standard [`Event` interface properties](https://dom.spec.whatwg.org/#interface-event) are not implemented.	
+
+#### Quick App (Xiaomi, Huawei)
+
+[`Event` interface's](https://doc.quickapp.cn/widgets/common-events.html) properties:
+
+- `type`
+- `timeStamp`
+- `target`
+- `currentTarget`
+
+#### Alipay Mini Program
+
+[`BaseEvent` interface's](https://opendocs.alipay.com/mini/framework/event-object) properties:
+
+- `type`
+- `timeStamp`
+- `target`
+
+#### Baidu Smart Mini Program
+
+Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
+
+- `type`
+- `timeStamp`
+- `target`
+- `currentTarget`
+- `detail`
+- `touches`
+- `changedTouches`
+
+
+### Stylesheets (CSS Profile)
+
+MiniApp vendors use CSS3 profiles (a subset of the [standard](https://www.w3.org/TR/CSS/)) with minor additions.
+
+#### Quick App (Xiaomi, Huawei)
+
+CSS3 profile, and supports preprocessing (i.e., LESS and SASS).
+
+Only supports a [subset of selectors and properties](https://doc.quickapp.cn/widgets/common-styles.html), and `px`, `dp` (device independent pixels), and `%` as units
+
+Read [the specification](https://doc.quickapp.cn/tutorial/framework/page-style-and-layout.html).
+
+#### Alipay Mini Program
+
+CSS3 profile named [ACSS](https://opendocs.alipay.com/mini/framework/acss), compatible with CSS3.
+
+ACSS adds `rpx` (responsive pixel), and a specific `page` selector.
+
+#### Baidu Smart Mini Program
+
+Specific CSS3 profile. 
+
+It adds `rpx` (responsive pixel).
+
+See [the specification](https://smartprogram.baidu.com/docs/develop/framework/view_css/).
+
+
+### Stylesheets (inline declaration)
+
+#### Quick App (Xiaomi, Huawei)
+
+`style` attribute in the template elements.	
+
+``` xml
+<template> 
+   <div style="flex-direction: column;"></div>
+</template>	
+```
+
+#### Alipay Mini Program
+
+`style` attribute in the template elements.
+
+``` xml
+<view style="color:#ffffff“ />		
+```
+
+#### Baidu Smart Mini Program
+
+`style` attribute in the SWAN template elements.	
+
+``` xml
+<view style="color: #ffffff"> swan </view>
+```
+
+#### Web Components
+
+`style` attribute in the elements.	
+
+
+### Stylesheets (import)
+
+The different MiniApp versions use similar [`@import`](https://developer.mozilla.org/en-US/docs/Web/CSS/@import) at-rule mechanisms.  
+
+#### Quick App (Xiaomi, Huawei)
+
+`@import` at-rule within the `<style>` section.
+
+``` html
+<style>
+  @import './style.css';
+</style>	
+```
+
+#### Alipay Mini Program
+
+`@import` at-rule within the `.acss` document.
+
+``` css
+@import "./button.acss" ; 
+@import "/common/button.acss" ;
+```
+
+#### Baidu Smart Mini Program
+
+`@import` at-rule within the `.css` document.
+
+``` css
+@import "header.css";
+```
+	
+### Component interface (properties)
+
+All the MiniApp versions have different component interfaces (they don't use [`HTMLElement` interface](https://html.spec.whatwg.org/multipage/dom.html#htmlelement)).  
+
+#### Quick App (Xiaomi, Huawei)
+
+[Predefined components' properties](https://doc.quickapp.cn/framework/script.html):
+
+- `data`
+- `props`
+- `computed`
+- `externalClasses`
+- `$app`
+- `$page`
+
+#### Alipay Mini Program
+
+[Predefined components' properties](https://opendocs.alipay.com/mini/framework/component_object): 
+
+- `data`
+- `props`
+- `is`
+- `$id`
+- `router`
+- `pageRouter`
+- `$page`
+
+#### Baidu Smart Mini Program
+
+[Predefined components' properties](https://smartprogram.baidu.com/docs/develop/framework/custom-component_comp/):
+
+- `is`
+- `id`
+- `dataset`
+- `data`
+- `properties`
+
+### Component interface (methods)
+
+All the MiniApp versions have different non-standard component interfaces (they don't use [`HTMLElement` interface](https://html.spec.whatwg.org/multipage/dom.html#htmlelement)).  
+
+#### Quick App (Xiaomi, Huawei)
+
+Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
+
+- `$valid()`
+- `$visible()`
+- `$attrs()`
+- `$listeners()`
+- `$element()`
+- `$root()`
+- `$parent()`
+- `$child()`
+- `$nextTick()`
+- `$forceUpdate()`
+
+
+#### Alipay Mini Program
+
+Predefined [component's methods](https://opendocs.alipay.com/mini/framework/component_object):
+
+- `setData()`
+- `$spliceData()`
+- `createSelectorQuery()`
+- `createIntersectionObserver()`
+- `selectOwnerComponent()`
+- `selectComponsedParentComponent()`
+
+#### Baidu Smart Mini Program
+
+Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
+
+- `setData()`
+- `hasBehavior` 
+- `createSelectorQuery()`
+- `createIntersectionObserver()`
+- `triggerEvent()`
+- `selectComponent()`
+- `selectAllComponents()`
+- `groupSetData()`
+
+
+
+
 Even for similar UI components, there are some gaps for different vendor's events handling. First, different vendors use different names for the same event. For example, for the “tap” event, Alipay and Baidu named “tap” while Huawei named “click”. Second, even if different vendors have the same name for the same event, different deployments may still exist. For example, for the “longtap” event, Alipay describes it as touch and leave after more than 500 ms. Baidu describes as more than 350ms.
 
 This may lead to repeated learning and repeated development by developers. Therefore, we propose to define a standard set of UI common components for MiniApp. That allows codes to easily migrate to different platforms, reduce repetitive development, and provide the same user experience.

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -32,7 +32,6 @@
       - [Lifecycle](#lifecycle)
       - [Stylesheets (CSS Profile)](#stylesheets-css-profile)
       - [Stylesheets (inline declaration)](#stylesheets-inline-declaration)
-      - [Web Components](#web-components)
       - [Stylesheets (import)](#stylesheets-import)
       - [Component interface (properties)](#component-interface-properties)
       - [Component interface (methods)](#component-interface-methods)

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -5,6 +5,38 @@
 - Zitao Wang (Huawei)
 - Martin Alvarez (Huawei)
 
+## Table of contents
+
+- [MiniApp Components Explainer](#miniapp-components-explainer)
+  - [Authors](#authors)
+  - [1. Introduction](#1-introduction)
+    - [What is this?](#what-is-this)
+    - [Why should we care?](#why-should-we-care)
+  - [2. Scope of work](#2-scope-of-work)
+    - [Out of scope](#out-of-scope)
+    - [What kind of document will be produced?](#what-kind-of-document-will-be-produced)
+  - [3. Key considerations](#3-key-considerations)
+    - [Differences with Web Components](#differences-with-web-components)
+      - [Component resources](#component-resources)
+      - [Component markup language](#component-markup-language)
+      - [Templating](#templating)
+      - [Component reuse (instantiation)](#component-reuse-instantiation)
+      - [Component properties (definition)](#component-properties-definition)
+      - [Component arguments](#component-arguments)
+      - [Data binding](#data-binding)
+      - [Event binding](#event-binding)
+      - [Event listener definition](#event-listener-definition)
+      - [Event types](#event-types)
+      - [Event interface properties](#event-interface-properties)
+      - [Lifecycle](#lifecycle)
+      - [Stylesheets (CSS Profile)](#stylesheets-css-profile)
+      - [Stylesheets (inline declaration)](#stylesheets-inline-declaration)
+      - [Web Components](#web-components)
+      - [Stylesheets (import)](#stylesheets-import)
+      - [Component interface (properties)](#component-interface-properties)
+      - [Component interface (methods)](#component-interface-methods)
+    - [Essential MiniApp elements](#essential-miniapp-elements)
+
 ## 1. Introduction
 
 ### What is this?

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -11,37 +11,37 @@
 
 MiniApp Components are the building blocks to creating MiniApp pages. Each component encapsulates functionality, data, and styles, enabling developers to create custom and reusable items that can be combined to develop MiniApps. MiniApps include essential components like page containers, textual and multimedia content, and other interactive elements such as forms.
 
-This document aims to specify a set of common practices to define MiniApps Components that allow developers to build similar user interfaces across MiniApp platforms efficiently, and provide a consistent user experience.
+This document aims to specify a set of common practices to define MiniApps Components that allow developers to build similar user interfaces across MiniApp platforms efficiently and provide a consistent user experience.
 
 
 ### Why should we care?
 
 Although MiniApps Components share the same concept as Web Components, their capabilities and development features differ. The main differences are motivated by the architecture of the existing implementations along the MiniApp ecosystem following the MVVM pattern, based on components developed through domain-specific markup languages and without access to the standard DOM. 
 
-Even though [[[MINIAPP-PACKAGING]]] recommends MiniApp agents to support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
+Even though the MiniApp Packaging specification recommends MiniApp agents to support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
 
 ## 2. Scope of work
 
 The MiniApp Components specification aims to collect the minimum set of common features from all the MiniApp versions, including: 
 
-- Built-in components (elements) names and properties
+- Built-in components (elements), names and properties
 - Event handling and basic event types 
-- High level features for component definition
+- High-level features for component definition
 
 ### Out of scope
 
 - Definition of HTML elements
-- Definition of beaviour or appearance of elements.
+- Definition of behavior or appearance of elements.
 - Definition of a markup language for MiniApp
 
 ### What kind of document will be produced?
 
-To avoid overlap and confusion with Web Components and other recommendations in W3C, this specification aims to be an informative reference and is not intended to be a formal standard. Thus, this specification will be published as a Group Note, with formal review, but not endorsed by W3C.
+To avoid overlap and confusion with Web Components and other recommendations in W3C, this specification aims to be an informative reference and is not intended to be a formal standard. Thus, this specification will be published as a Group Note with a formal review but not be endorsed by W3C.
 
 This document will follow the principles below:
 
 - Identify the common practices and existing implementations regarding MiniApp components;
-- Maximize reuse and alignment of the specification with the existing standards (specially HTML, CSS and DOM); and
+- Maximize reuse and alignment of the specification with the existing standards (especially HTML, CSS, and DOM); and
 - Alignment with other groups in W3C (i.e., [OpenUI CG](https://open-ui.org/)) providing feedback and collecting new requirements that could serve to enhance the existing standards.
 
 
@@ -53,16 +53,16 @@ This section analyzes the differences between the standard Web Components and th
 
 The main differences identified are:
 
-- __Component resources__. MiniApps require specific resource types, including markup languages, and file system structure. 
+- __Component resources__. MiniApps require specific resource types, including markup languages and file system structure. 
 - __Component interface__. MiniApp components have specific properties and methods. Access to global variables and page elements differs in all versions. 
-- __Template definition__. MiniApps have advanced `{{moustache}}` templating mechanism with data binding and conditional rendering.
+- __Template definition__. MiniApps have an advanced `{{moustache}}` templating mechanism with data binding and conditional rendering.
 - __Event management__. MiniApp event listeners are similar, but developers cannot use the `addEventListener()` method from the logic. Event interfaces are different.
-- __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties and rules are similar. 
+- __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties, and rules are similar. 
 
 
 #### Component resources
 
-Depending on the implementation, MiniApp components are defined using specific file formats and resources to describe templates, logic and styles.
+Depending on the implementation, MiniApp components are defined using specific file formats and resources to describe templates, logic, and styles.
 
 ##### Quick App (Xiaomi, Huawei)
 
@@ -119,7 +119,7 @@ Component ( {
 })
 ```
 
-`.json` to indicate that the current directory files defines a component.
+`.json` to indicate that the current directory files define a component.
 
 ```js
 // /components/index/index.json
@@ -144,7 +144,7 @@ Component ( {
 
 Baidu Smart Mini Programs enable the creation of components using four resources in the same directory: `.swan`, `.js`, `.json`, and `.css`.
 
-`.swan`. SWAN file including the template.
+`.swan` with the SWAN file, including the template.
 
 ```xml
 <!-- /components/custom/custom.swan -->
@@ -173,7 +173,7 @@ Component ({
 })
 ```
 
-`.json` to indicate that the current directory files defines a component.
+`.json` to indicate that the current directory files define a component.
 
 ```js
 // /components/custom/custom.json
@@ -215,7 +215,7 @@ The component [templates are described](https://doc.quickapp.cn/framework/templa
 </template>
 ```
 
-Quick Apps offer advanced rendering controls (including conditionals, loops and decorators), as well as data and event binding. 
+Quick Apps offer advanced rendering controls (including conditionals, loops, and decorators) and data and event binding. 
 
 
 ##### Alipay Mini Program
@@ -233,7 +233,7 @@ The component [templates are described](https://opendocs.alipay.com/mini/framewo
 </template>
 ```
 
-Alipay Mini Programs offer advanced rendering controls (including conditionals and loops), as well as data and event binding. 
+Alipay Mini Programs offer advanced rendering controls (including conditionals and loops), and data and event binding. 
 
 ##### Baidu Smart Mini Program
 
@@ -252,7 +252,7 @@ Baidu Smart Mini Programs offer advanced rendering controls (including condition
 
 #### Templating
 
-Web Components are defined in terms of [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) and [templating](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) with	`<template>`, and `<slot>`.	MiniApps have different specifications.
+Web Components are defined in terms of [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) and [templating](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) with	`<template>` and `<slot>`.	MiniApps have different specifications.
  
 
 ##### Quick App (Xiaomi, Huawei)
@@ -299,7 +299,7 @@ SWAN document with elements within.
 [More information](https://smartprogram.baidu.com/docs/develop/framework/dev/).
 
 
-#### Component re-use (instantiation)
+#### Component reuse (instantiation)
 
 How developers reuse the components defined in the [previous section](#templating). 
 
@@ -417,7 +417,7 @@ How the properties (attributes) are passed to the components when new instances 
 
 ##### Quick App (Xiaomi, Huawei)
 
-Use the defined `props` directly as instance's attributes.
+Use the defined `props` directly as instance attributes.
 
 ```xml
 <import name="comp" src="./comp"></import>
@@ -437,7 +437,7 @@ Use the defined `props` directly as instance's attributes.
 
 ##### Alipay Mini Program
 
-Pass the properties as as instance's attributes.
+Pass the properties as instance attributes.
 
 ```xml
 <!-- /pages/index/index.axml -->
@@ -448,7 +448,7 @@ Pass the properties as as instance's attributes.
 
 ##### Baidu Smart Mini Program
 
-Properties as instance's attributes
+Properties as instance attributes
 
 ```js
 // home.json
@@ -472,7 +472,7 @@ Properties as instance's attributes
 
 #### Data binding
 
-All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to bind variables from the logic part of the component.
+All the MiniApp versions have [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to bind variables from the logic part of the component.
 
 ##### Quick App (Xiaomi, Huawei)
 
@@ -536,7 +536,7 @@ Page({
 
 #### Event binding
 
-All the MiniApp version have similar mechanism to add event handlers from the template. MiniApps cannot bind listeners using `addEventListener()` from scripts.
+All the MiniApp versions have a similar mechanism to add event handlers from the template. MiniApps cannot bind listeners using `addEventListener()` from scripts.
 
 ##### Quick App (Xiaomi, Huawei)
 
@@ -628,7 +628,7 @@ Event types by default are different. Not all the standard [event types](https:/
 
 Different vendors use different names for the same event type. For example, `tap` event in Alipay and Baidu Mini Programs, but `click` in Quick Apps. 
 
-Also, even if different vendors have the same name for the same event the implementation is different. For example, for the `longtap` event, Alipay Mini Programs trigger the event after 500 ms after the first contact, while Baidu Smart Mini Programs' period is 350 ms.
+Also, implementations are different even if vendors use the same name for the same event. For example, the `longtap` event, Alipay Mini Programs trigger the event 500 ms after the first contact, while Baidu Smart Mini Programs' period is 350 ms.
 
 ##### Quick App (Xiaomi, Huawei)
 
@@ -879,9 +879,9 @@ Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
 
 ### Essential MiniApp elements
 
-MiniApp elements are the building blocks for describing the structure and content of MiniApp Components. This section will analyze the differences among the built-in components or elements in each MiniApp version and the standard HTML. 
+MiniApp elements are the building blocks for describing the structure and content of MiniApp Components. This section will analyze the differences between the built-in components or elements in each MiniApp version and the standard HTML. 
 
-The table below includes an analysis of the MiniApp elements available in the existing MiniApp specifications. Each row represents an element and the semantically equivalent(s) from each specification, without considering the details in terms of attributes or behavior.
+The table below includes an analysis of the MiniApp elements available in the existing MiniApp specifications. Each row represents an element and the semantically equivalent(s) from each specification without considering the details in terms of attributes or behavior.
 
 
 | Feature        | W3C Spec                                                        | [QuickApp (Xiaomi, Huawei)](https://www.quickapp.cn/) | [Alipay Mini Program](https://docs.alipay.com/mini/developer/) | [Baidu Smart Mini Program](https://smartprogram.baidu.com/developer/index.html) |

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -11,7 +11,8 @@
 
 MiniApp Components are the building blocks to creating MiniApp pages. Each component encapsulates functionality, data, and styles, enabling developers to create custom and reusable items that can be combined to develop MiniApps. MiniApps include essential components like page containers, textual and multimedia content, and other interactive elements such as forms.
 
-This document aims to specify a set of common practices to define MiniApps Components that allow developers to build similar user interfaces across MiniApp platforms efficiently.
+This document aims to specify a set of common practices to define MiniApps Components that allow developers to build similar user interfaces across MiniApp platforms efficiently, and provide a consistent user experience.
+
 
 ### Why should we care?
 
@@ -19,8 +20,34 @@ Although MiniApps Components share the same concept as Web Components, their cap
 
 Even though [[[MINIAPP-PACKAGING]]] recommends MiniApp agents to support standard Web Components, MiniApp vendors might opt to implement the internal components using the traditional MVVM architecture and, subsequently, manage them through non-standard mechanisms like virtual DOM (VDOM) or content interpolation.
 
+## 2. Scope of work
 
-## 2. Differences with Web Components
+The MiniApp Components specification aims to collect the minimum set of common features from all the MiniApp versions, including: 
+
+- Built-in components (elements) names and properties
+- Event handling and basic event types 
+- High level features for component definition
+
+### Out of scope
+
+- Definition of HTML elements
+- Definition of beaviour or appearance of elements.
+- Definition of a markup language for MiniApp
+
+### What kind of document will be produced?
+
+To avoid overlap and confusion with Web Components and other recommendations in W3C, this specification aims to be an informative reference and is not intended to be a formal standard. Thus, this specification will be published as a Group Note, with formal review, but not endorsed by W3C.
+
+This document will follow the principles below:
+
+- Identify the common practices and existing implementations regarding MiniApp components;
+- Maximize reuse and alignment of the specification with the existing standards (specially HTML, CSS and DOM); and
+- Alignment with other groups in W3C (i.e., [OpenUI CG](https://open-ui.org/)) providing feedback and collecting new requirements that could serve to enhance the existing standards.
+
+
+## 3. Key considerations
+
+### Differences with Web Components
 
 This section analyzes the differences between the standard Web Components and the MiniApp components, considering the existing vendor-specific implementations, Baidu Smart Mini Programs, Alipay Mini Programs, and Quick Apps (Huawei, Xiaomi). 
 
@@ -33,11 +60,11 @@ The main differences identified are:
 - __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties and rules are similar. 
 
 
-### Component resources
+#### Component resources
 
 Depending on the implementation, MiniApp components are defined using specific file formats and resources to describe templates, logic and styles.
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Quick App uses [UX documents](https://doc.quickapp.cn/framework/source-file.html) (`.ux`) to describe and use components. These documents contains three sections, `<template>`, `<script>`, and `<style>`, that include the specific template definition, logic and styling respectively. 
 
@@ -66,7 +93,7 @@ Example:
 
 ``` 
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 Alipay Mini Program components may have four resources in the same directory: `.axml`, `.js`, `.json`, and `.acss`.
 
@@ -114,7 +141,7 @@ Component ( {
 [Read more](https://opendocs.alipay.com/mini/framework/custom-component-overview).
 
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Baidu Smart Mini Programs enable the creation of components using four resources in the same directory: `.swan`, `.js`, `.json`, and `.css`.
 
@@ -168,11 +195,11 @@ Component ({
 [Read more](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
 
 
-### Component markup language
+#### Component markup language
 
 Although the MiniApp components templates are based on HTML, the concrete implementations use their domain-specific markup languages.    
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Quick Apps use a concrete notation for UX documents. Scripts, stylesheets and templates are defined under the same document, marked with the elements `<script>`, `<style>`, and `<template>`. 
 
@@ -192,7 +219,7 @@ The component [templates are described](https://doc.quickapp.cn/framework/templa
 Quick Apps offer advanced rendering controls (including conditionals, loops and decorators), as well as data and event binding. 
 
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 Alipay Mini Programs use a concrete AXML notation for the templates described in `.axml` documents. These documents are similar to XML, but without a root node.
 
@@ -209,7 +236,7 @@ The component [templates are described](https://opendocs.alipay.com/mini/framewo
 
 Alipay Mini Programs offer advanced rendering controls (including conditionals and loops), as well as data and event binding. 
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Baidu Smart Mini Programs use [SWAN resources](https://smartprogram.baidu.com/docs/develop/framework/dev/). Developers use `.swan` documents to create rendering templates for the pages. 
 
@@ -224,12 +251,12 @@ Baidu Smart Mini Programs use [SWAN resources](https://smartprogram.baidu.com/do
 Baidu Smart Mini Programs offer advanced rendering controls (including conditionals and loops), as well as data and event binding. 
 
 
-### Templating
+#### Templating
 
 Web Components are defined in terms of [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) and [templating](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) with	`<template>`, and `<slot>`.	MiniApps have different specifications.
  
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Definition of `<template>` element in the root of a `.ux` document.
 
@@ -244,7 +271,7 @@ Definition of `<template>` element in the root of a `.ux` document.
 
 [More information](https://doc.quickapp.cn/framework/template.html).	
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 AXML’s `<template>` element in an `.axml` document.
 
@@ -259,7 +286,7 @@ AXML’s `<template>` element in an `.axml` document.
 
 [More information](https://opendocs.alipay.com/mini/framework/axml-template).	
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 SWAN document with elements within.
 
@@ -273,11 +300,11 @@ SWAN document with elements within.
 [More information](https://smartprogram.baidu.com/docs/develop/framework/dev/).
 
 
-### Component re-use (instantiation)
+#### Component re-use (instantiation)
 
 How developers reuse the components defined in the [previous section](#templating). 
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 `<import>` element in the root of the `.ux` document.
 
@@ -293,7 +320,7 @@ How developers reuse the components defined in the [previous section](#templatin
 
 [More information](https://doc.quickapp.cn/framework/template.html).	
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 AXML’s `<import>` and `<template is=...` elements.
 
@@ -305,7 +332,7 @@ AXML’s `<import>` and `<template is=...` elements.
 
 [More information](https://opendocs.alipay.com/mini/framework/axml-template).
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Declaration in the configuration (`.json`) document. 
 
@@ -330,11 +357,11 @@ And declaration in the SWAN document using the ID in the configuration file.
 [More information](https://smartprogram.baidu.com/docs/develop/framework/dev/).
 
 
-### Component properties (definition)
+#### Component properties (definition)
 
 How the properties (attributes) of the components are defined in each MiniApp version. 
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Components define properties in a `props` array within the object declared in the `<script>` section.     
 
@@ -352,7 +379,7 @@ Components define properties in a `props` array within the object declared in th
 ```
 [More information](https://doc.quickapp.cn/tutorial/framework/parent-child-component-communication.html).
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 Definition of the component using `Component()` and the properties as pairs in the `props` object.
 
@@ -366,7 +393,7 @@ Component ({
 [More information](https://opendocs.alipay.com/mini/framework/component_object).
 
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Definition of the component using `Component()` and the properties in the `properties` object.
 
@@ -385,11 +412,11 @@ Component({
 [More information](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
 
 
-### Component arguments
+#### Component arguments
 
 How the properties (attributes) are passed to the components when new instances are created. 
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Use the defined `props` directly as instance's attributes.
 
@@ -409,7 +436,7 @@ Use the defined `props` directly as instance's attributes.
 [More information](https://doc.quickapp.cn/tutorial/framework/parent-child-component-communication.html).	
 
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 Pass the properties as as instance's attributes.
 
@@ -420,7 +447,7 @@ Pass the properties as as instance's attributes.
 
 [More information](https://opendocs.alipay.com/mini/framework/component_object).	
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Properties as instance's attributes
 
@@ -444,11 +471,11 @@ Properties as instance's attributes
 [More information](https://smartprogram.baidu.com/docs/develop/framework/custom-component/).
 
 
-### Data binding
+#### Data binding
 
 All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) to bind variables from the logic part of the component.
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables and methods under the `private` or `public` object in the script.
 
@@ -469,7 +496,7 @@ All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org
 [More information](https://doc.quickapp.cn/framework/template.html).	
 
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in the AXML file linked to the `Page()` corresponding `data` object variables.
 
@@ -487,7 +514,7 @@ Page({
                                 
 [More information](https://opendocs.alipay.com/mini/framework/data-binding).
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in SWAN template, linked to the `Page()` corresponding `data` object variables.
 
@@ -508,11 +535,11 @@ Page({
 [More information](https://smartprogram.baidu.com/docs/develop/framework/app_service_pagedata/).
 	
 
-### Event binding
+#### Event binding
 
 All the MiniApp version have similar mechanism to add event handlers from the template. MiniApps cannot bind listeners using `addEventListener()` from scripts.
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 `on+eventtype` (or `@+eventtype`) attribute in the template. 
 
@@ -522,7 +549,7 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 
 [More information](https://doc.quickapp.cn/tutorial/framework/event-on.html).	
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 `on+eventtype` attribute in the template.
 
@@ -534,7 +561,7 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 
 [More information](https://opendocs.alipay.com/mini/framework/events).	
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 `bind:+eventtype` attribute in the template.
 
@@ -547,11 +574,11 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 [More information](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
 
 
-### Event listener definition
+#### Event listener definition
 
 In MiniApps, listeners must be defined in specific places in the logic of the component. 
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 `function()` declaration as root of the object in `<script>`.
 
@@ -567,7 +594,7 @@ In MiniApps, listeners must be defined in specific places in the logic of the co
 
 [More information](https://doc.quickapp.cn/tutorial/framework/event-on.html).	
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 `function()` declaration in the root of the `Page({})` declaration in the script.
 
@@ -581,7 +608,7 @@ Page ({
 
 [More information](https://opendocs.alipay.com/mini/framework/events).	
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 `function()` declaration in the root of the `Page({})` declaration in the script.
 
@@ -596,11 +623,15 @@ Page({
 [More information](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
 
 
-### Event types
+#### Event types
 
-Event types by default are different. Not all the standard [event types](https://html.spec.whatwg.org/multipage/indices.html#events-2) are supported.	
+Event types by default are different. Not all the standard [event types](https://html.spec.whatwg.org/multipage/indices.html#events-2) are supported. 
 
-#### Quick App (Xiaomi, Huawei)
+Different vendors use different names for the same event type. For example, `tap` event in Alipay and Baidu Mini Programs, but `click` in Quick Apps. 
+
+Also, even if different vendors have the same name for the same event the implementation is different. For example, for the `longtap` event, Alipay Mini Programs trigger the event after 500 ms after the first contact, while Baidu Smart Mini Programs' period is 350 ms.
+
+##### Quick App (Xiaomi, Huawei)
 
 [Basic events](https://doc.quickapp.cn/tutorial/framework/event-on.html):
 
@@ -617,7 +648,7 @@ Event types by default are different. Not all the standard [event types](https:/
 - `swipe`
 - `resize`
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 [Basic events](https://opendocs.alipay.com/mini/framework/events):
 
@@ -628,7 +659,7 @@ Event types by default are different. Not all the standard [event types](https:/
 - `tap`
 - `longTap`
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 [Basic events](https://smartprogram.baidu.com/docs/develop/framework/view_incident/):
 
@@ -639,11 +670,11 @@ Event types by default are different. Not all the standard [event types](https:/
 - `tap`
 
 
-### Event interface properties
+#### Event interface properties
 
 MiniApps have different basic event interfaces. Standard [`Event` interface properties](https://dom.spec.whatwg.org/#interface-event) are not implemented.	
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 [`Event` interface's](https://doc.quickapp.cn/widgets/common-events.html) properties:
 
@@ -652,7 +683,7 @@ MiniApps have different basic event interfaces. Standard [`Event` interface prop
 - `target`
 - `currentTarget`
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 [`BaseEvent` interface's](https://opendocs.alipay.com/mini/framework/event-object) properties:
 
@@ -660,7 +691,7 @@ MiniApps have different basic event interfaces. Standard [`Event` interface prop
 - `timeStamp`
 - `target`
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/framework/view_incident/).
 
@@ -673,11 +704,11 @@ Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/
 - `changedTouches`
 
 
-### Stylesheets (CSS Profile)
+#### Stylesheets (CSS Profile)
 
 MiniApp vendors use CSS3 profiles (a subset of the [standard](https://www.w3.org/TR/CSS/)) with minor additions.
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 CSS3 profile, and supports preprocessing (i.e., LESS and SASS).
 
@@ -685,13 +716,13 @@ Only supports a [subset of selectors and properties](https://doc.quickapp.cn/wid
 
 Read [the specification](https://doc.quickapp.cn/tutorial/framework/page-style-and-layout.html).
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 CSS3 profile named [ACSS](https://opendocs.alipay.com/mini/framework/acss), compatible with CSS3.
 
 ACSS adds `rpx` (responsive pixel), and a specific `page` selector.
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Specific CSS3 profile. 
 
@@ -700,9 +731,11 @@ It adds `rpx` (responsive pixel).
 See [the specification](https://smartprogram.baidu.com/docs/develop/framework/view_css/).
 
 
-### Stylesheets (inline declaration)
+#### Stylesheets (inline declaration)
 
-#### Quick App (Xiaomi, Huawei)
+The different MiniApp versions use the same `style` attribute to declare inline styles.  
+
+##### Quick App (Xiaomi, Huawei)
 
 `style` attribute in the template elements.	
 
@@ -712,7 +745,7 @@ See [the specification](https://smartprogram.baidu.com/docs/develop/framework/vi
 </template>	
 ```
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 `style` attribute in the template elements.
 
@@ -720,7 +753,7 @@ See [the specification](https://smartprogram.baidu.com/docs/develop/framework/vi
 <view style="color:#ffffff“ />		
 ```
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 `style` attribute in the SWAN template elements.	
 
@@ -733,11 +766,11 @@ See [the specification](https://smartprogram.baidu.com/docs/develop/framework/vi
 `style` attribute in the elements.	
 
 
-### Stylesheets (import)
+#### Stylesheets (import)
 
 The different MiniApp versions use similar [`@import`](https://developer.mozilla.org/en-US/docs/Web/CSS/@import) at-rule mechanisms.  
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 `@import` at-rule within the `<style>` section.
 
@@ -747,7 +780,7 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 </style>	
 ```
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 `@import` at-rule within the `.acss` document.
 
@@ -756,7 +789,7 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 @import "/common/button.acss" ;
 ```
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 `@import` at-rule within the `.css` document.
 
@@ -764,11 +797,11 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 @import "header.css";
 ```
 	
-### Component interface (properties)
+#### Component interface (properties)
 
 All the MiniApp versions have different component interfaces (they don't use [`HTMLElement` interface](https://html.spec.whatwg.org/multipage/dom.html#htmlelement)).  
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 [Predefined components' properties](https://doc.quickapp.cn/framework/script.html):
 
@@ -779,7 +812,7 @@ All the MiniApp versions have different component interfaces (they don't use [`H
 - `$app`
 - `$page`
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 [Predefined components' properties](https://opendocs.alipay.com/mini/framework/component_object): 
 
@@ -791,7 +824,7 @@ All the MiniApp versions have different component interfaces (they don't use [`H
 - `pageRouter`
 - `$page`
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 [Predefined components' properties](https://smartprogram.baidu.com/docs/develop/framework/custom-component_comp/):
 
@@ -801,11 +834,11 @@ All the MiniApp versions have different component interfaces (they don't use [`H
 - `data`
 - `properties`
 
-### Component interface (methods)
+#### Component interface (methods)
 
 All the MiniApp versions have different non-standard component interfaces (they don't use [`HTMLElement` interface](https://html.spec.whatwg.org/multipage/dom.html#htmlelement)).  
 
-#### Quick App (Xiaomi, Huawei)
+##### Quick App (Xiaomi, Huawei)
 
 Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
 
@@ -821,7 +854,7 @@ Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
 - `$forceUpdate()`
 
 
-#### Alipay Mini Program
+##### Alipay Mini Program
 
 Predefined [component's methods](https://opendocs.alipay.com/mini/framework/component_object):
 
@@ -832,7 +865,7 @@ Predefined [component's methods](https://opendocs.alipay.com/mini/framework/comp
 - `selectOwnerComponent()`
 - `selectComponsedParentComponent()`
 
-#### Baidu Smart Mini Program
+##### Baidu Smart Mini Program
 
 Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
 
@@ -845,86 +878,57 @@ Predefined [component's methods](https://doc.quickapp.cn/framework/script.html):
 - `selectAllComponents()`
 - `groupSetData()`
 
+### Essential MiniApp elements
+
+MiniApp elements are the building blocks for describing the structure and content of MiniApp Components. This section will analyze the differences among the built-in components or elements in each MiniApp version and the standard HTML. 
+
+The table below includes an analysis of the MiniApp elements available in the existing MiniApp specifications. Each row represents an element and the semantically equivalent(s) from each specification, without considering the details in terms of attributes or behavior.
 
 
-
-Even for similar UI components, there are some gaps for different vendor's events handling. First, different vendors use different names for the same event. For example, for the “tap” event, Alipay and Baidu named “tap” while Huawei named “click”. Second, even if different vendors have the same name for the same event, different deployments may still exist. For example, for the “longtap” event, Alipay describes it as touch and leave after more than 500 ms. Baidu describes as more than 350ms.
-
-This may lead to repeated learning and repeated development by developers. Therefore, we propose to define a standard set of UI common components for MiniApp. That allows codes to easily migrate to different platforms, reduce repetitive development, and provide the same user experience.
-
-## 2. MiniApp Common UI Components
-Given the above problems, we select UI components common to existing widely deployed applets and standardize them. The common UI components may include as following.
-* **Basic Components**:
-Basic components provide the minimum interactive blocks that can be reused for the MiniApp. Developers can define the user interface of the MiniApp by combining these basic components. It may include the following components such as 'Image', 'Progress', 'Text', 'Input', 'Button', 'Label', 'Select', 'Slider', 'Switch', 'Picker', 'Video', and 'Canvas'.
-* **Container Components**:
-Container components provide the structure of a MiniApp page. It may inculdes the following components such as 'Div', 'List', 'Swiper', 'Tabs', and 'Refresh'.
-### Scope of work:
-The MiniApp Common UI Components specification aims to standardize on:
-- Component names and properties
-- States
-- Behaviors
-- How behaviors transition state 
-### Out of Scope:
-- Appearance of the component
-- Markup Language for MiniApp 
-
-### How to standardize the common UI components
-Standardized MiniApp UI proposals will be based on the following principles:
-- Identify the scope of the common UI based on the existing implementation;
-- Reuse the existing standards as much as possible and extend them to support the attributes and events required by the MiniApp;
-- Alignment with standards bodies like OpenUI CG to define new elements (e.g., picker, tab).
-
-### Key Considerations 
-
-#### How to implementate the standard MiniApp common UI components?
-
-
-## 3. Comparison with existing standard UI components 
-
-The following table mainly describes the comparison between the MiniApp common UI components and W3C standards compontents:
-MiniApp Common UI Components | Attributes | Events | Similar Standard Component 
-:---    |:---    |:--        |:---     
-div | - | - | Constraint of standard attributes and different events
-list | - | scrollend | Element event scroll as the standard
-list-item | - | - | - |
-swiper | index, loop, vertical | change | - |
-tabs | index, vertical, disabled, focusable, data | - | tabs for HTML (OpenUI) |
-tab-bar | mode | - | - |
-tab-content | scrollable | - | CSS overflow: scroll |
-refresh | offset, type, refreshing, lasttime, friction, disabled, focusable, data | - | Similar to SwipeRefreshLayout, but more related to the user agent instead of the document. |
-image | src, alt, disabled, focusable & complete, error | - | &lt;img&gt; with attributes src and alt are the standard |
-progress | type, focusable, data | - | &lt;progress&gt; element (max, value, position, labels) |
-text | focusable, data | - | Similar to SVG’s text. |
-input | type, placeholder…, headericon, disable, focusable | change | input element (with all types supported), attribute disabled, no headericon. |
-button | type (styles instead of function), value, icon, waiting, focusable* | - | button element, attribute disabled, no waiting, no icon. (in OpenUI) |
-label | focusable | - | label element. Labelable elements: button, input, meter, output, progress, select, textarea |
-select | data | - | select element. Attribute disabled (in OpenUI) |
-slider | min, max, value, data | change | input@type=”range” (in OpenUI) |
-switch | - | - | - |
-picker | type (text, date, time, datetime, multi-text) | - | input element (date, time, datetime-local) and datalist element (with attribute options). |
-video | muted, src, autoplay, poster, controls | prepared, seeked, timeupdate, fullscreenchange | video element with all the attributes but (disable, and focusable) + vents: readyState, buffered  (but not prepared, seeked, timeupdate, fullscreenchange) |
-canvas | disable, focusable, data | - | canvas element |
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+| Feature        | W3C Spec                                                        | [QuickApp (Xiaomi, Huawei)](https://www.quickapp.cn/) | [Alipay Mini Program](https://docs.alipay.com/mini/developer/) | [Baidu Smart Mini Program](https://smartprogram.baidu.com/developer/index.html) |
+| -------------- | --------------------------------------------------------------- | ----------------------- | ---------------- | ---------------------- |
+| div            | `<div>`                                                         | `<div>`                   | `<view>`           | `<view>`                 |
+| span           | `<span>`                                                        | `<span>`                  |                  |                        |
+| stack          |                                                                 | `<stack>`                 | `<cover-view>`     | `<cover-view>`           |
+| carousel       |                                                                 | `<swiper>`                | `<swiper>`         | `<swiper>`               |
+| tabs           | [OpenUI research](https://open-ui.org/components/tabs.research) | `<tabs>`                  |                  | `<tabs>`                 |
+| refresh        |                                                                 | `<refresh>`               |                  |                        |
+| icon           | [OpenUI research](https://open-ui.org/components/icon.research) |                         | `<icon>`           | `<icon>`                 |
+| progress       | `<progress>`                                                    | `<progress>`              | `<progress>`       | `<progress>`             |
+| anchor         | a                                                               | `<a>`                       | `<navigator>`      | `<navigator>`            |
+| text           | `<span>`                                                        | `<text>`                  | `<text>`           | `<text>`                 |
+| text input     | `<input>`                                                       | `<input>`                 | `<input>`          | `<input>`                |
+| camera         | `<input>`                                                       | `<camera>`                |                  | `<camera>`               |
+| textarea       | `<textarea>`                                                    | `<textarea>`              | `<textarea>`       | `<textarea>`             |
+| checkbox       | `<input type="checkbox">`                                       | `<input type="checkbox">` | `<checkbox>`       | `<checkbox>`             |
+| radio          | `<input type="radio">`                                          | `<input type="radio">`    | `<radio>`          | `<radio>`                |
+| form           | `<form>`                                                        |                         | `<form>`           | `<form>`                 |
+| button         | `<button>`                                                      | `<input type="button">`   | `<button>`         | `<button>`               |
+| label          | `<label>`                                                         | `<label>`                 | `<label>`          | `<label>`                |
+| select         | [`<select>`](https://open-ui.org/components/select)               | `<select>`                | `<picker>`         | `<picker>`               |
+| slider         | `<input>`                                                         | `<slider>`                | `<slider>`         | `<slider>`               |
+| switch         | [OpenUI research](https://open-ui.org/components/switch)        | `<switch>`                | `<switch>`         | `<switch>`               |
+| picker         | [OpenUI proposal](https://open-ui.org/components/select)        | `<picker>`                | `<picker>`         | `<picker>`               |
+| image          | `<img>`                                                           | `<image>`                 | `<image>`          | `<image>`                |
+| audio          | `<audio>`                                                         |                         |                  | `<audio>`                |
+| video          | `<video>`                                                         | `<video>`                 | `<video>`          | `<video>`                |
+| canvas         | `<canvas>`                                                        | `<canvas>`                | `<canvas>`         | `<canvas>`               |
+| animation      |                                                                 | `<lottie>`                | `<lottie>`         | `<animation-video>`      |
+| web-view       | `<html>`                                                          | `<web>`                   | `<web-view>`       | `<web-view>`             |
+| map            |                                                                 | `<map>`                   | `<map>`            | `<map>`                  |
+| list           |                                                                 | `<list>`                  |                  |                        |
+| popup          | `<dialog>`                                                        | `<popup>`                 |                  |                        |
+| rtc-room       |                                                                 |                         |                  | `<rtc-room>`             |
+| ad             |                                                                 |                         |                  | `<ad>`                   |
+| payment        |                                                                 |                         |                  | `<inline-payment-panel>` |
+| comments       |                                                                 |                         |                  | `<comment-list>`         |
+| like           |                                                                 |                         |                  | `<like>`                 |
+| 3d-model       | `<model>` (WIP)                                                   |                         |                  | `<modelviewer>`          |
+| rating         |                                                                 | `<rating>`                |                  |                        |
+| marquee        |                                                                 | `<marquee>`               |                  |                        |
+| share-button   |                                                                 | `<share-button>`          |                  |                        |
+| drawer         |                                                                 | `<drawer>`                |                  |                        |
+| match-media    |                                                                 |                         | `<match-media>`    |                        |
+| aria-component |                                                                 |                         | `<aria-component>` |                        |
+| page metadata  |                                                                 |                         | `<page-meta>`      |                        |
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -63,9 +63,9 @@ The MiniApp Components specification aims to collect the minimum set of common f
 
 ### Out of scope
 
-- Definition of HTML elements
+- Definition of HTML elements.
 - Definition of behavior or appearance of elements.
-- Definition of a markup language for MiniApp
+- Definition of a markup language for MiniApps.
 
 ### What kind of document will be produced?
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -24,7 +24,7 @@ Even though the MiniApp Packaging specification recommends that MiniApp agents s
 
 The MiniApp Components specification aims to collect the minimum set of common features from all the MiniApp versions, including: 
 
-- Built-in components (elements), names and properties
+- Built-in components (elements), names, and properties
 - Event handling and basic event types 
 - High-level features for component definition
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -740,7 +740,7 @@ Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/
 
 [Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) are extensions of [HTML elements](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) that need to be registered to be used in the document. Apart from the inherited event handlers, custom elements have associated specific callbacks associated with their lifecycle statuses and events. 
 
-- `connectedCallback` invoked when the custom element is first connected to the document's DOM. 
+- `connectedCallback` is invoked when the custom element is first connected to the document's DOM. 
 - `disconnectedCallback` invoked when the custom element is disconnected from the document's DOM.
 - `adoptedCallback` is invoked when the custom element is moved to a new document.
 - `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed. 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -704,6 +704,98 @@ Properties of the [Event interface](https://smartprogram.baidu.com/docs/develop/
 - `changedTouches`
 
 
+#### Lifecycle
+
+[Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) are extension of [HTML elements](https://html.spec.whatwg.org/multipage/dom.html#htmlelement) that need to be registered to be used in the document. Apart from the inherited event handlers, custom elements have associated specific callbacks associated with their lifecycle statuses and events. 
+
+- `connectedCallback` invoked when the custom element is first connected to the document's DOM. 
+- `disconnectedCallback` invoked when the custom element is disconnected from the document's DOM.
+- `adoptedCallback` is invoked when the custom element is moved to a new document.
+- `attributeChangedCallback` is invoked when one of the custom element's attributes is added, removed, or changed. 
+
+
+##### Quick App (Xiaomi, Huawei)
+
+
+Quick App custom components implement the following lifecycle callbacks:
+
+- `onInit` triggered when all the data of the component is loaded and the system starts connecting the component.
+- `onReady` triggered when the component is rendered for the first time.
+- `onDestroy` triggered when the component is destroyed.
+
+
+```html
+<script>
+  export default {
+    onReady() {
+      console.log('Ready');
+    }  
+  }
+</script>
+```
+
+
+[More information](https://doc.quickapp.cn/framework/script.html#%E8%87%AA%E5%AE%9A%E4%B9%89%E7%BB%84%E4%BB%B6%E7%9A%84%E7%94%9F%E5%91%BD%E5%91%A8%E6%9C%9F-1050).	
+
+##### Alipay Mini Program
+
+Quick App custom components implement the following lifecycle callbacks:
+
+- `onInit` triggered when the component is created.
+- `deriveDataFromProps` triggered when the component is created and before it is updated.
+- `didUpdate`	triggered when the component data has been updated.
+- `didMount` triggered when the component is rendered for the first time.
+- `didUnmount` triggered when the component is removed.
+
+Example:
+
+```js
+// /components/index/index.js
+Component ({
+  data: {
+    counter: 0, 
+  },
+  onInit ( ) {
+    this.setData ({
+      counter: 1 , 
+      is : this.is, 
+    });
+  },
+});
+```
+
+[More information](https://opendocs.alipay.com/mini/framework/component-lifecycle).	
+
+##### Baidu Smart Mini Program
+
+Smart Mini Programs define the following callbacks triggered in the different phases of the lifecycle:
+
+- `created` triggered when the component instance is created.
+- `attached` triggered when the component is attached to the document.
+- `ready` triggered when the component is rendered for the first time.
+- `detached` triggered when the component is removed from the document.
+
+These callbacks are defined in the `lifetimes` parameter of the component, as shown in the following example.
+
+```js
+// custom-component.js
+Component({
+    // ...
+    lifetimes: {
+        attached: function() {
+          console.log('Attached');
+        },
+        detached: function() {
+          console.log('Detached');
+        }
+    }
+    // ...
+});
+```
+
+[More information](https://smartprogram.baidu.com/docs/develop/framework/custom-component_lifetimes/).
+
+
 #### Stylesheets (CSS Profile)
 
 MiniApp vendors use CSS3 profiles (a subset of the [standard](https://www.w3.org/TR/CSS/)) with minor additions.

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -2,8 +2,9 @@
 
 ## Authors
 
-- Zitao Wang (Huawei)
 - Martin Alvarez (Huawei)
+- Thomas Steiner (Google)
+- Zitao Wang (Huawei)
 
 ## Table of contents
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -87,7 +87,7 @@ This section analyzes the differences between the standard Web Components and th
 The main differences identified are:
 
 - __Component resources__. MiniApps require specific resource types, including markup languages and file system structure. 
-- __Component interface__. MiniApp components have specific properties and methods. Access to global variables and page elements differs in all versions. 
+- __Component interface__. MiniApps components have specific properties and methods. Access to global variables and page elements differs in all versions. 
 - __Template definition__. MiniApps have an advanced `{{moustache}}` templating mechanism with data binding and conditional rendering.
 - __Event management__. MiniApp event listeners are similar, but developers cannot use the `addEventListener()` method from the logic. Event interfaces are different.
 - __Stylesheets__. MiniApps are based on CSS3 profiles, with minor additions. Imports, properties, and rules are similar. 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -354,7 +354,7 @@ How developers reuse the components defined in the [previous section](#templatin
 
 ##### Alipay Mini Program
 
-AXML’s `<import>` and `<template is=...` elements.
+AXML's `<import>` and `<template is=...` elements.
 
 ```xml
 <import src="./header.axml" />

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -661,7 +661,7 @@ Event types by default are different. Not all the standard [event types](https:/
 
 Different vendors use different names for the same event type. For example, `tap` event in Alipay and Baidu Mini Programs, but `click` in Quick Apps. 
 
-Also, implementations are different even if vendors use the same name for the same event. For example, the `longtap` event, Alipay Mini Programs trigger the event 500 ms after the first contact, while Baidu Smart Mini Programs' period is 350 ms.
+Also, implementations are different even if vendors use the same name for the same event. For example, the `longtap` event: Alipay Mini Programs trigger the event 500 ms after the first contact, while Baidu Smart Mini Programs' period is 350 ms.
 
 ##### Quick App (Xiaomi, Huawei)
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -182,7 +182,7 @@ Baidu Smart Mini Programs enable the creation of components using four resources
 ```xml
 <!-- /components/custom/custom.swan -->
 <view class="name" bindtap="tap">
-    {{name}}{{age}}
+    {{name}} {{age}}
 </view>
 ```
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -233,7 +233,7 @@ Although the MiniApp components templates are based on HTML, the concrete implem
 
 ##### Quick App (Xiaomi, Huawei)
 
-Quick Apps use a concrete notation for UX documents. Scripts, stylesheets and templates are defined under the same document, marked with the elements `<script>`, `<style>`, and `<template>`. 
+Quick Apps use a concrete notation for UX documents. Scripts, stylesheets, and templates are defined in the same document, marked with the elements `<script>`, `<style>`, and `<template>`. 
 
 The component [templates are described](https://doc.quickapp.cn/framework/template.html) as an XML fragment within the `<template>` section, using HTML-like elements.
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -24,9 +24,10 @@ Even though the MiniApp Packaging specification recommends that MiniApp agents s
 
 The MiniApp Components specification aims to collect the minimum set of common features from all the MiniApp versions, including: 
 
-- Built-in components (elements), names, and properties
-- Event handling and basic event types 
-- High-level features for component definition
+- Built-in components (elements), names, and properties;
+- Event handling and basic event types;
+- High-level features for component definition;
+- Lifecycle.
 
 ### Out of scope
 

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -70,7 +70,7 @@ Quick App uses [UX documents](https://doc.quickapp.cn/framework/source-file.html
 
 Example:
 
-``` xml
+```xml
 <template>
   <div>
     <text class="title" onclick="press">Hello</text>
@@ -90,16 +90,15 @@ Example:
     color: red;
   }
 </style>
-
 ``` 
 
 ##### Alipay Mini Program
 
 Alipay Mini Program components may have four resources in the same directory: `.axml`, `.js`, `.json`, and `.acss`.
 
-`.axml`. AXML file including the template.
+`.axml` with a AXML file that includes the template.
 
-``` xml
+```xml
 <!-- /components/index/index.axml -->
 <view>
   Hi, I'm a component.
@@ -108,7 +107,7 @@ Alipay Mini Program components may have four resources in the same directory: `.
 
 `.js` for component registration.
 
-``` js
+```js
 // /components/index/index.js
 Component ( {
   mixins :  [ ] ,
@@ -122,7 +121,7 @@ Component ( {
 
 `.json` to indicate that the current directory files defines a component.
 
-``` json
+```js
 // /components/index/index.json
 {
   "component" : true 
@@ -131,7 +130,7 @@ Component ( {
 
 `.acss`. ACSS document with the stylesheet.
 
-``` css
+```css
 /** /components/index/index.acss **/
 .md-button  {
   padding : 15px ; 
@@ -147,7 +146,7 @@ Baidu Smart Mini Programs enable the creation of components using four resources
 
 `.swan`. SWAN file including the template.
 
-``` xml
+```xml
 <!-- /components/custom/custom.swan -->
 <view class="name" bindtap="tap">
     {{name}}{{age}}
@@ -156,7 +155,7 @@ Baidu Smart Mini Programs enable the creation of components using four resources
 
 `.js` for component registration.
 
-``` js
+```js
 // /components/custom/custom.js
 Component ({
   properties: { 
@@ -176,7 +175,7 @@ Component ({
 
 `.json` to indicate that the current directory files defines a component.
 
-``` json
+```js
 // /components/custom/custom.json
 {
   "component" : true 
@@ -185,7 +184,7 @@ Component ({
 
 `.css`. CSS document with the stylesheet.
 
-``` css
+```css
 /** /components/index/index.css **/
 .name {
     color: red;
@@ -205,7 +204,7 @@ Quick Apps use a concrete notation for UX documents. Scripts, stylesheets and te
 
 The component [templates are described](https://doc.quickapp.cn/framework/template.html) as an XML fragment within the `<template>` section, using HTML-like elements.
 
-``` xml
+```xml
 <template>
   <div>
     <div for="{{list}}" tid="uniqueId">
@@ -225,7 +224,7 @@ Alipay Mini Programs use a concrete AXML notation for the templates described in
 
 The component [templates are described](https://opendocs.alipay.com/mini/framework/axml) using specific elements.
 
-``` xml
+```xml
 <!-- axml -->
 <template  name="task">
   <view  class="task-item" >
@@ -240,7 +239,7 @@ Alipay Mini Programs offer advanced rendering controls (including conditionals a
 
 Baidu Smart Mini Programs use [SWAN resources](https://smartprogram.baidu.com/docs/develop/framework/dev/). Developers use `.swan` documents to create rendering templates for the pages. 
 
-``` xml
+```xml
 <view>
     <custom-component>
         <view>{{name}}</view>
@@ -260,7 +259,7 @@ Web Components are defined in terms of [Custom Elements](https://developer.mozil
 
 Definition of `<template>` element in the root of a `.ux` document.
 
-``` xml
+```xml
 <!–- file.ux -->
 <template>
   <div class="demo-page">
@@ -275,7 +274,7 @@ Definition of `<template>` element in the root of a `.ux` document.
 
 AXML’s `<template>` element in an `.axml` document.
 
-``` xml
+```xml
 <!-- header.axml -->
 <template name="header">
   <view>
@@ -290,7 +289,7 @@ AXML’s `<template>` element in an `.axml` document.
 
 SWAN document with elements within.
 
-``` xml
+```xml
 <view>
     <text class="wrap">hello world</text>
 </view>
@@ -308,7 +307,7 @@ How developers reuse the components defined in the [previous section](#templatin
 
 `<import>` element in the root of the `.ux` document.
 
-``` xml
+```xml
 <import name="comp" src="./comp"></import>
 
 <template>
@@ -324,7 +323,7 @@ How developers reuse the components defined in the [previous section](#templatin
 
 AXML’s `<import>` and `<template is=...` elements.
 
-``` xml
+```xml
 <import src="./header.axml" />
 
 <template is="header" data="{{...item}}"/>
@@ -336,7 +335,7 @@ AXML’s `<import>` and `<template is=...` elements.
 
 Declaration in the configuration (`.json`) document. 
 
-``` json
+```js
 // home.json
 {
   "usingComponents": {
@@ -347,7 +346,7 @@ Declaration in the configuration (`.json`) document.
 
 And declaration in the SWAN document using the ID in the configuration file.
 
-``` xml
+```xml
 <!-- home.swan -->
 <view>
    <custom name="swanapp"></custom>
@@ -365,7 +364,7 @@ How the properties (attributes) of the components are defined in each MiniApp ve
 
 Components define properties in a `props` array within the object declared in the `<script>` section.     
 
-``` html
+```html
 <!-– comp.ux -->
 <script>
   export default {
@@ -383,7 +382,7 @@ Components define properties in a `props` array within the object declared in th
 
 Definition of the component using `Component()` and the properties as pairs in the `props` object.
 
-``` js
+```js
 // /components/index/index.js
 Component ({
   props : { 
@@ -397,7 +396,7 @@ Component ({
 
 Definition of the component using `Component()` and the properties in the `properties` object.
 
-``` js
+```js
 // (custom.js)
 Component({
   properties: {
@@ -420,7 +419,7 @@ How the properties (attributes) are passed to the components when new instances 
 
 Use the defined `props` directly as instance's attributes.
 
-``` xml
+```xml
 <import name="comp" src="./comp"></import>
 
 <template>
@@ -440,7 +439,7 @@ Use the defined `props` directly as instance's attributes.
 
 Pass the properties as as instance's attributes.
 
-``` xml
+```xml
 <!-- /pages/index/index.axml -->
 <comp name='Another name'></comp> 
 ```
@@ -451,7 +450,7 @@ Pass the properties as as instance's attributes.
 
 Properties as instance's attributes
 
-``` json
+```js
 // home.json
 {
   "usingComponents": {
@@ -460,7 +459,7 @@ Properties as instance's attributes
 }
 ```
 
-``` xml
+```xml
 // .swan document
 <view>
     <custom name="Passing text" >
@@ -479,7 +478,7 @@ All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables and methods under the `private` or `public` object in the script.
 
-``` xml
+```xml
 <template>
   <text>{{message}}</text>
 </template>
@@ -500,11 +499,11 @@ All the MiniApp version have [`{{moustache}}` notation](https://en.wikipedia.org
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in the AXML file linked to the `Page()` corresponding `data` object variables.
 
-``` xml
+```xml
 <view> {{ message }} </view>
 ```
 
-``` js
+```js
 Page({ 
    data: { 
      message: 'Hello alipay!', 
@@ -518,12 +517,12 @@ Page({
 
 [`{{moustache}}` notation](https://en.wikipedia.org/wiki/Mustache_%28template_system%29) with variables in SWAN template, linked to the `Page()` corresponding `data` object variables.
 
-``` xml
+```xml
 <!-- index.swan -->
 <view>{{text}}</view>
 ```
 
-``` js
+```js
 // index.js
 Page({
     data: {
@@ -543,7 +542,7 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 
 `on+eventtype` (or `@+eventtype`) attribute in the template. 
 
-``` xml
+```xml
 <text onclick="loadMore"></text>
 ```
 
@@ -553,7 +552,7 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 
 `on+eventtype` attribute in the template.
 
-``` xml
+```xml
 <view onTap="loadMore">
   More items…
 <view> 
@@ -565,7 +564,7 @@ All the MiniApp version have similar mechanism to add event handlers from the te
 
 `bind:+eventtype` attribute in the template.
 
-``` xml
+```xml
 <view bind:tap="loadMore">
    More items…
 </view>
@@ -582,7 +581,7 @@ In MiniApps, listeners must be defined in specific places in the logic of the co
 
 `function()` declaration as root of the object in `<script>`.
 
-``` html
+```html
 <script>
   export default {
     loadMore(e) {
@@ -598,7 +597,7 @@ In MiniApps, listeners must be defined in specific places in the logic of the co
 
 `function()` declaration in the root of the `Page({})` declaration in the script.
 
-``` js
+```js
 Page ({
   loadMore(e) {
     console.log(e);
@@ -612,7 +611,7 @@ Page ({
 
 `function()` declaration in the root of the `Page({})` declaration in the script.
 
-``` js
+```js
 Page({
   loadMore(e) {
     swan.showToast(e.type);
@@ -739,7 +738,7 @@ The different MiniApp versions use the same `style` attribute to declare inline 
 
 `style` attribute in the template elements.	
 
-``` xml
+```xml
 <template> 
    <div style="flex-direction: column;"></div>
 </template>	
@@ -749,7 +748,7 @@ The different MiniApp versions use the same `style` attribute to declare inline 
 
 `style` attribute in the template elements.
 
-``` xml
+```xml
 <view style="color:#ffffff“ />		
 ```
 
@@ -757,7 +756,7 @@ The different MiniApp versions use the same `style` attribute to declare inline 
 
 `style` attribute in the SWAN template elements.	
 
-``` xml
+```xml
 <view style="color: #ffffff"> swan </view>
 ```
 
@@ -774,7 +773,7 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 
 `@import` at-rule within the `<style>` section.
 
-``` html
+```html
 <style>
   @import './style.css';
 </style>	
@@ -784,7 +783,7 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 
 `@import` at-rule within the `.acss` document.
 
-``` css
+```css
 @import "./button.acss" ; 
 @import "/common/button.acss" ;
 ```
@@ -793,7 +792,7 @@ The different MiniApp versions use similar [`@import`](https://developer.mozilla
 
 `@import` at-rule within the `.css` document.
 
-``` css
+```css
 @import "header.css";
 ```
 	


### PR DESCRIPTION
One of the missing pieces in the MiniApps specifications is how to define the content of a MiniApp. The MiniApp Packaging spec indicates that MiniApp implementations may support Web Components, but all the existing MiniApp versions define their components in a different way. This explainer collects information about the key features of MiniApp Components, comparing all the existing implementations.

This analysis motivates the creation of a new specification, **MiniApp Components**, to identify and define the minimum set of common features to guarantee interoperability among the MiniApp platforms.  

+@MichaelWangzitao 